### PR TITLE
Outlaw nil keys in job parameters. Coerce all values to strings

### DIFF
--- a/lib/oncue.rb
+++ b/lib/oncue.rb
@@ -1,6 +1,7 @@
 require 'redis'
 require 'time'
 require 'job'
+require 'oncue_exception'
 require 'json'
 
 module OnCue
@@ -27,7 +28,10 @@ module OnCue
   def enqueue_job(worker_type, params={})
     raise 'params must be a set of key-value pairs' unless params.kind_of? Hash
 
-
+    params.merge!(params) do |key, value|
+      raise OnCueException, 'nil is not a valid key' if key.nil?
+      value.nil? ? nil : value.to_s
+    end
 
     # Connect to redis
     redis = Redis.new(:host => "localhost", :port => 6379)

--- a/lib/oncue_exception.rb
+++ b/lib/oncue_exception.rb
@@ -1,0 +1,7 @@
+module OnCue
+
+  class OnCueException < StandardError
+
+  end
+
+end

--- a/spec/oncue_spec.rb
+++ b/spec/oncue_spec.rb
@@ -27,7 +27,6 @@ describe OnCue do
     end
 
     context 'with params' do
-
       context 'that are not key value pairs' do
         it 'should reject the job' do
           expect { OnCue.enqueue_job('oncue.workers.TestWorker', ['an array']) }.to raise_error
@@ -52,7 +51,165 @@ describe OnCue do
         end
       end
     end
+    context 'with parameter keys that are' do
+
+      let(:stored_params) do
+        job = OnCue.enqueue_job('oncue.workers.TestWorker', {key => 'value'})
+        job_key = OnCue::JOB_KEY % { :job_id => 1 }
+        JSON.parse(redis.hget(job_key, OnCue::JOB_PARAMS))
+      end
+
+      context 'nil' do
+        let(:key) {nil}
+
+        it 'throws an error' do
+          expect {stored_params}.to raise_error
+        end
+      end
+
+      context 'strings' do
+        let(:key) {'a string'}
+
+        it 'converts them to strings' do
+          stored_params.should == {'a string' => 'value'}
+        end
+      end
+
+      context 'integers' do
+        let(:key) {10}
+        it 'converts them to strings' do
+          stored_params.should == {'10' => 'value'}
+        end
+      end
+      context 'decimals' do
+        let(:key) {10.23}
+        it 'converts them to strings' do
+          stored_params.should == {'10.23' => 'value'}
+        end
+      end
+
+      context 'the boolean true' do
+        let(:key) {true}
+        it 'converts them to strings' do
+          stored_params.should == {'true' => 'value'}
+        end
+      end
+
+      context 'the boolean false' do
+        let(:key) {false}
+        it 'converts them to strings' do
+          stored_params.should == {'false' => 'value'}
+        end
+      end
+
+      context 'symbols' do
+        let(:key) {:a_symbol}
+        it 'converts them to strings' do
+          stored_params.should == {'a_symbol' => 'value'}
+        end
+      end
+
+      context 'arrays' do
+        let(:key) {[1,true,'string']}
+        it 'converts them to strings' do
+          stored_params.should == {'[1, true, "string"]' => 'value'}
+        end
+      end
+
+      context 'maps' do
+        let(:key) {{1 => false}}
+        it 'converts them to strings' do
+          stored_params.should == {'{1=>false}' => 'value'}
+        end
+      end
+
+      context 'arbitrary objects' do
+        let(:key) {Object.new}
+        it 'converts them to strings using the to_s method' do
+          stored_params.keys[0].should =~ /Object.*/
+        end
+      end
+    end
+
+    context 'with parameter values that are' do
+
+      let(:stored_params) do
+        job = OnCue.enqueue_job('oncue.workers.TestWorker', {'key' => value})
+        job_key = OnCue::JOB_KEY % { :job_id => 1 }
+        JSON.parse(redis.hget(job_key, OnCue::JOB_PARAMS))
+      end
 
 
+      context 'nil' do
+        let(:value) {nil}
+
+        it 'leaves them as nil' do
+          stored_params.should == {'key' => nil}
+        end
+      end
+
+      context 'strings' do
+        let(:value) {'a string'}
+
+        it 'converts them to strings' do
+          stored_params.should == {'key' => 'a string'}
+        end
+      end
+
+      context 'integers' do
+        let(:value) {10}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => '10'}
+        end
+      end
+      context 'decimals' do
+        let(:value) {10.23}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => '10.23'}
+        end
+      end
+
+      context 'the boolean true' do
+        let(:value) {true}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => 'true'}
+        end
+      end
+
+      context 'the boolean false' do
+        let(:value) {false}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => 'false'}
+        end
+      end
+
+      context 'symbols' do
+        let(:value) {:a_symbol}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => 'a_symbol'}
+        end
+      end
+
+      context 'arrays' do
+        let(:value) {[1,true,'string']}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => '[1, true, "string"]'}
+        end
+      end
+
+      context 'maps' do
+        let(:value) {{1 => false}}
+        it 'converts them to strings' do
+          stored_params.should == {'key' => '{1=>false}'}
+        end
+      end
+
+      context 'arbitrary objects' do
+        let(:value) {Object.new}
+        it 'converts them to strings using the to_s method' do
+          stored_params.should == {'key' => value.to_s}
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This change coerces all parameter values to strings before serialisation into Redis.

e.g. 

```
{'key1' => 'value', 'key2' => 1, 'key3' => true}
```

is serialised into JSON as:

```
{"key1":"value","key2":"1","key3":"true"}
```

`maps`, `arrays` and other complex objects are serialised using their default `to_s` method but usage is discouraged.
