### PR TITLE
Change naming scheme for API requests

### DIFF
--- a/lib/oncue.rb
+++ b/lib/oncue.rb
@@ -23,7 +23,7 @@ module OnCue
 
     params = OnCue::Parameters.convert_param_values_to_strings(params)
 
-    request_json = JSON.dump(workerType: worker_type.to_s, params: params)
+    request_json = JSON.dump(worker_type: worker_type.to_s, params: params)
 
     response_body = make_request(configuration.jobs_url, request_json)
 

--- a/lib/oncue/job.rb
+++ b/lib/oncue/job.rb
@@ -12,7 +12,7 @@ module OnCue
     end
 
     def self.json_create(o)
-      new(o['id'], o['enqueuedAt'])
+      new(o['id'], o['enqueued_at'])
     end
 
     def ==(other)

--- a/spec/oncue/job_spec.rb
+++ b/spec/oncue/job_spec.rb
@@ -9,7 +9,7 @@ describe OnCue::Job do
 
     let(:id) { 1 }
     let(:enqueued_at) { '2013-03-26T12:34:56' }
-    let(:json) { { 'id' => id, 'enqueuedAt' => enqueued_at } }
+    let(:json) { { 'id' => id, 'enqueued_at' => enqueued_at } }
 
     subject(:created_job) { OnCue::Job.json_create(json) }
 
@@ -20,7 +20,7 @@ describe OnCue::Job do
         created_job.enqueued_at.should eq DateTime.new(2013, 03, 26, 12, 34, 56)
       end
 
-      context 'where enqueuedAt is not IS8061 formatted' do
+      context 'where enqueued_at is not IS8061 formatted' do
 
         let(:enqueued_at) { 'Thursday 28th Match 2013' }
 

--- a/spec/oncue_spec.rb
+++ b/spec/oncue_spec.rb
@@ -91,10 +91,10 @@ describe OnCue do
       let(:jobs_url) { 'http://test/' }
 
       let(:params) { {'a' => 'b'}}
-      let(:request_body) {  "{\"workerType\":\"#{worker_type}\",\"params\":#{JSON.dump(params)}}" }
+      let(:request_body) {  "{\"worker_type\":\"#{worker_type}\",\"params\":#{JSON.dump(params)}}" }
 
       let(:status) { 200 }
-      let(:response_body) { '{"id":1,"enqueuedAt":"2013-03-26T12:34:56"}' }
+      let(:response_body) { '{"id":1,"enqueued_at":"2013-03-26T12:34:56"}' }
 
       before do
         OnCue.configuration.should_receive(:jobs_url).and_return(jobs_url)
@@ -104,7 +104,7 @@ describe OnCue do
             headers: {
               'Accept'=>'application/json',
               'Accept-Encoding'=>'gzip, deflate',
-              'Content-Length'=>'54',
+              'Content-Length'=>request_body.length,
               'Content-Type'=>'application/json',
               'User-Agent'=>'Ruby'
             }
@@ -132,7 +132,7 @@ describe OnCue do
 
           context 'with a non ISO8601-formatted date' do
 
-            let(:response_body) { '{"id":1,"enqueuedAt":"Thursday 28th March 2013"}' }
+            let(:response_body) { '{"id":1,"enqueued_at":"Thursday 28th March 2013"}' }
 
             it do
               expect { enqueue_job }.to raise_error OnCue::UnexpectedServerResponse


### PR DESCRIPTION
This change uses 'enqueued_at' and 'worker_type' instead of 'enqueuedAt' and 'workerType'. This reflects the changes made in https://github.com/michaelmarconi/oncue/commit/9c8132415fa036d8c3a97802ce69560c3d5e0f23.

The wiki in oncue has been updated. See https://github.com/michaelmarconi/oncue/wiki/RESTful-API.
