### PR TITLE
Upgrade JSON dependency to 1.8.2 to support Ruby 2.2.0

### DIFF
--- a/lib/oncue/version.rb
+++ b/lib/oncue/version.rb
@@ -1,3 +1,3 @@
 module OnCue
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/oncue.gemspec
+++ b/oncue.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec_junit_formatter', '~> 0.1.5'
 
   gem.add_runtime_dependency 'addressable', '~> 2.3.3'
-  gem.add_runtime_dependency 'json', '~> 1.7.7'
+  gem.add_runtime_dependency 'json', '~> 1.8.2'
   gem.add_runtime_dependency 'rest-client', '~> 1.6.7'
 
 end


### PR DESCRIPTION
One of the string manipulation functions has changed it's C API in Ruby 2.2.0 and thus version 1.7.7 of the json gem will not build for it.

This updates the dependency to use 1.8.2.

For more information: https://github.com/flori/json/issues/229

NOTE: This will drop support for Ruby 1.8.7.